### PR TITLE
tokenizer is required, fix #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ include
 install-sh
 libtool
 ltmain.sh
+ltmain.sh.backup
 missing
 mkinstalldirs
 modules

--- a/config.m4
+++ b/config.m4
@@ -12,7 +12,8 @@ if test "$PHP_PCS" != "no"; then
 		fi
 	fi
 	PHP_NEW_EXTENSION(pcs, php_pcs.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
-	# PCS must be loaded after SPL
+	# PCS must be loaded after tokenizer and SPL
+	PHP_ADD_EXTENSION_DEP(pcs, tokenizer)
 	PHP_ADD_EXTENSION_DEP(pcs, spl)
 fi
 

--- a/php_pcs.c
+++ b/php_pcs.c
@@ -242,8 +242,16 @@ static PHP_MSHUTDOWN_FUNCTION(pcs)
 /*---------------------------------------------------------------*/
 /*-- Module definition --*/
 
+static const zend_module_dep pcs_deps[] = {
+	ZEND_MOD_REQUIRED("tokenizer")
+	ZEND_MOD_REQUIRED("SPL")
+	ZEND_MOD_END
+};
+
 zend_module_entry pcs_module_entry = {
-	STANDARD_MODULE_HEADER,
+	STANDARD_MODULE_HEADER_EX,
+	NULL,
+	pcs_deps,
 	MODULE_NAME,
 	NULL,
 	PHP_MINIT(pcs),


### PR DESCRIPTION
Detected by phpcompatinfo analyse 

```
 $ phpcompatinfo analyser:run php/src/internal/

 Data Source Analysed

 Directories                                          2
 Files                                                4

 Extensions Analysis

     Extension Matches REF       EXT min/Max PHP min/Max PHP all 
     Core              Core      5.1.0       5.1.0               
     pcre              pcre      4.0.0       4.0.0               
     standard          standard  5.0.0       5.0.0               
     tokenizer         tokenizer 5.4.0       5.4.0               
     Total [4]                               5.4.0               
 ...
```
