### PR TITLE
fix build with PHP < 5.3.7

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -12,8 +12,9 @@ if test "$PHP_PCS" != "no"; then
 		fi
 	fi
 	PHP_NEW_EXTENSION(pcs, php_pcs.c, $ext_shared,, -DZEND_ENABLE_STATIC_TSRMLS_CACHE=1)
-	# PCS must be loaded after tokenizer and SPL
+	# PCS must be loaded after tokenizer, pcre, and SPL
 	PHP_ADD_EXTENSION_DEP(pcs, tokenizer)
+	PHP_ADD_EXTENSION_DEP(pcs, pcre)
 	PHP_ADD_EXTENSION_DEP(pcs, spl)
 fi
 

--- a/config.w32
+++ b/config.w32
@@ -3,6 +3,8 @@
 ARG_ENABLE("pcs", "enable the PHP Code Service", "no");
 
 if (PHP_PCS != "no") {
+		ADD_EXTENSION_DEP('pcs', 'tokenizer'); 
+		ADD_EXTENSION_DEP('pcs', 'pcre'); 
 		ADD_EXTENSION_DEP('pcs', 'spl'); 
         EXTENSION("pcs", "php_pcs.c", PHP_PCS_SHARED, "/DZEND_ENABLE_STATIC_TSRMLS_CACHE=1");
 }

--- a/php_pcs.c
+++ b/php_pcs.c
@@ -244,6 +244,7 @@ static PHP_MSHUTDOWN_FUNCTION(pcs)
 
 static const zend_module_dep pcs_deps[] = {
 	ZEND_MOD_REQUIRED("tokenizer")
+	ZEND_MOD_REQUIRED("pcre")
 	ZEND_MOD_REQUIRED("SPL")
 	ZEND_MOD_END
 };

--- a/php_pcs.c
+++ b/php_pcs.c
@@ -246,7 +246,12 @@ static const zend_module_dep pcs_deps[] = {
 	ZEND_MOD_REQUIRED("tokenizer")
 	ZEND_MOD_REQUIRED("pcre")
 	ZEND_MOD_REQUIRED("SPL")
+#ifdef ZEND_MOD_END
 	ZEND_MOD_END
+#else
+	/* for php < 5.3.7 */
+	{NULL, NULL, NULL}
+#endif
 };
 
 zend_module_entry pcs_module_entry = {


### PR DESCRIPTION
As package.xml say min version is 5.3.0... and RHEL-6 still have 5.3.3... and the fix is trivial...

ZEND_MOD_END was introduced in PHP 5.3.7 as  { NULL, NULL, NULL, 0 }, but previous versions expect  { NULL, NULL, NULL}
