### PR TITLE
Fix test suite for php 7.2

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -112,6 +112,7 @@ Compatibility : PHP 5 (5.3+) and 7
    </dir>
    <dir name="tests">
     <file name="autoload_001.phpt" role="test" />
+    <file name="autoload_002.phpt" role="test" />
     <file name="basic_001.phpt" role="test" />
     <file name="basic_002.phpt" role="test" />
     <file name="file_info_001.phpt" role="test" />

--- a/tests/autoload_002.phpt
+++ b/tests/autoload_002.phpt
@@ -1,15 +1,13 @@
 --TEST--
-__autoload() is functional
---SKIPIF--
-<?php if (PHP_VERSION_ID >= 70200) die("skip PHP < 7.2 only"); ?>
+spl_autoload() is functional
 --FILE--
 <?php
 
-function __autoload($sym)
+function my_autoload($sym)
 {
 var_dump($sym);
 }
-
+spl_autoload_register('my_autoload');
 class_exists('undefined');
 
 ?>


### PR DESCRIPTION
With PHP 7.2, the test fail with 
`001+ Deprecated: __autoload() is deprecated, use spl_autoload_register() instead in /work/GIT/pecl-pcs/tests/autoload_001.php on line 3`