### PR TITLE
Fix build where ZEND_FASTCALL doesn't match default call conv

### DIFF
--- a/src/PCS_Loader.h
+++ b/src/PCS_Loader.h
@@ -41,9 +41,15 @@ static PCS_Node *ParserInterface_node;
 
 static zend_string *parser_func_name;
 
-static void (*spl_register_handler)(INTERNAL_FUNCTION_PARAMETERS);
-static void (*spl_unregister_handler)(INTERNAL_FUNCTION_PARAMETERS);
-static void (*spl_functions_handler)(INTERNAL_FUNCTION_PARAMETERS);
+#if PHP_VERSION_ID >= 70300
+typedef void (ZEND_FASTCALL *pcs_zif_handler)(INTERNAL_FUNCTION_PARAMETERS);
+#else
+typedef void (*pcs_zif_handler)(INTERNAL_FUNCTION_PARAMETERS);
+#endif
+
+static pcs_zif_handler spl_register_handler;
+static pcs_zif_handler spl_unregister_handler;
+static pcs_zif_handler spl_functions_handler;
 static zend_function *pcs_autoload_func;
 static zend_function *spl_autoload_call_func;
 


### PR DESCRIPTION
As of PHP 7.3.0, internal function handlers use the `ZEND_FASTCALL`
calling convention.  On architectures where this doesn't match the
default calling convention, the build fails (or even worse things may
happen during runtime).

We fix this by typedeffing our own `pcs_zif_handler` according to the
PHP version.