### PR TITLE
Don't modify the internal array pointer

### DIFF
--- a/src/PCS_Loader.c
+++ b/src/PCS_Loader.c
@@ -384,6 +384,7 @@ static int PCS_Loader_registerNode(PCS_Node *node TSRMLS_DC)
 	zval ret, *zkey;
 	zend_string *zp;
 	HashTable *ht;
+	HashPosition pos;
 
 	ZEND_ASSERT(PCS_NODE_IS_FILE(node));
 	DBG_MSG1("-> PCS_Loader_registerNode(%s)",ZSTR_VAL(node->path));
@@ -460,9 +461,9 @@ static int PCS_Loader_registerNode(PCS_Node *node TSRMLS_DC)
 	ht = Z_ARRVAL(ret);
 
 	symcount = need_rinit = 0;
-	for (zend_hash_internal_pointer_reset(ht);;zend_hash_move_forward(ht)) {
-		if (zend_hash_has_more_elements(ht) != SUCCESS) break;
-		zkey = compat_zend_hash_get_current_zval(ht);
+	for (zend_hash_internal_pointer_reset_ex(ht, &pos);;zend_hash_move_forward_ex(ht, &pos)) {
+		if (zend_hash_has_more_elements_ex(ht, &pos) != SUCCESS) break;
+		zkey = compat_zend_hash_get_current_zval_ex(ht, &pos);
 		if (Z_TYPE_P(zkey) != IS_STRING) {
 			compat_zval_ptr_dtor(&ret);
 			php_error(E_CORE_ERROR, "%s: Elements returned by the parser should be strings"


### PR DESCRIPTION
Since the internal array pointer is shared for all code using a hash
table, this can easily lead to issues.  In this case we're failing an
assertion in `zend_hash_internal_pointer_reset_ex()`, because the ref
count is 2, while running tests/autoload_001.phpt.

We use our own position pointer instead.