### PR TITLE
AppVeyor CI integration

### DIFF
--- a/.appveyor/build.ps1
+++ b/.appveyor/build.ps1
@@ -1,0 +1,31 @@
+$ErrorActionPreference = "Stop"
+
+Set-Location 'c:\projects\pecl-pcs'
+
+$task = New-Item 'task.bat' -Force
+Add-Content $task "call phpize 2>&1"
+Add-Content $task "call configure --enable-pcs --enable-debug-pack 2>&1"
+Add-Content $task "nmake /nologo 2>&1"
+Add-Content $task "exit %errorlevel%"
+& "c:\build-cache\php-sdk-$env:BIN_SDK_VER\phpsdk-$env:VC-$env:ARCH.bat" -t $task
+if (-not $?) {
+    throw "build failed with errorlevel $LastExitCode"
+}
+
+$source = ''
+if ($env:ARCH -eq 'x64') {
+    $source += 'x64\'
+}
+$source += 'Release';
+if ($env:TS -eq '1') {
+    $source += '_TS'
+}
+
+$file = Get-Command php | Select-Object -ExpandProperty Definition
+$dest = (Get-Item $file).Directory.FullName
+
+Copy-Item "$source\php_pcs.dll" "$dest\ext\php_pcs.dll"
+
+$ini = New-Item "$dest\php-cli.ini" -Force
+Add-Content $ini "extension_dir=$dest\ext"
+Add-Content $ini 'extension=php_pcs.dll'

--- a/.appveyor/install.ps1
+++ b/.appveyor/install.ps1
@@ -1,0 +1,59 @@
+$ErrorActionPreference = "Stop"
+
+if (-not (Test-Path 'c:\build-cache')) {
+    [void](New-Item 'c:\build-cache' -ItemType 'directory')
+}
+
+$bname = "php-sdk-$env:BIN_SDK_VER.zip"
+Write-Host $bname
+if (-not (Test-Path c:\build-cache\$bname)) {
+    Invoke-WebRequest "https://github.com/microsoft/php-sdk-binary-tools/archive/$bname" -OutFile "c:\build-cache\$bname"
+}
+$dname0 = "php-sdk-binary-tools-php-sdk-$env:BIN_SDK_VER"
+$dname1 = "php-sdk-$env:BIN_SDK_VER"
+if (-not (Test-Path 'c:\build-cache\$dname1')) {
+    Expand-Archive "c:\build-cache\$bname" "c:\build-cache"
+    Move-Item "c:\build-cache\$dname0" "c:\build-cache\$dname1"
+}
+
+$releases = @{
+    '7.0' = '7.0.33';
+    '7.1' = '7.1.33';
+}
+if ($releases.ContainsKey($env:PHP_VER)) {
+    $phpversion = $releases.$env:PHP_VER;
+    $base_url = 'http://windows.php.net/downloads/releases/archives';
+} else {
+    $releases = Invoke-WebRequest https://windows.php.net/downloads/releases/releases.json | ConvertFrom-Json
+    $phpversion = $releases.$env:PHP_VER.version
+    $base_url = 'http://windows.php.net/downloads/releases';
+}
+
+$ts_part = ''
+if ($env:TS -eq '0') {
+    $ts_part += '-nts'
+}
+
+$bname = "php-devel-pack-$phpversion$ts_part-Win32-$env:VC-$env:ARCH.zip"
+if (-not (Test-Path "c:\build-cache\$bname")) {
+    Invoke-WebRequest "$base_url/$bname" -OutFile "c:\build-cache\$bname"
+}
+$dname0 = "php-$phpversion-devel-$env:VC-$env:ARCH"
+$dname1 = "php-$phpversion$ts_part-devel-$env:VC-$env:ARCH"
+if (-not (Test-Path "c:\build-cache\$dname1")) {
+    Expand-Archive "c:\build-cache\$bname" "c:\build-cache"
+    if ($dname0 -ne $dname1) {
+        Move-Item "c:\build-cache\$dname0" "c:\build-cache\$dname1"
+    }
+}
+$env:PATH = "c:\build-cache\$dname1;$env:PATH"
+
+$bname = "php-$phpversion$ts_part-Win32-$env:VC-$env:ARCH.zip"
+if (-not (Test-Path "c:\build-cache\$bname")) {
+    Invoke-WebRequest "$base_url/$bname" -OutFile "c:\build-cache\$bname"
+}
+$dname = "php-$phpversion$ts_part-$env:VC-$env:ARCH"
+if (-not (Test-Path "c:\build-cache\$dname")) {
+    Expand-Archive "c:\build-cache\$bname" "c:\build-cache\$dname"
+}
+$env:PATH = "c:\build-cache\$dname;$env:PATH"

--- a/.appveyor/test.ps1
+++ b/.appveyor/test.ps1
@@ -1,0 +1,9 @@
+$ErrorActionPreference = "Stop"
+
+Set-Location 'c:\projects\pecl-pcs'
+
+$env:TEST_PHP_EXECUTABLE = Get-Command 'php' | Select-Object -ExpandProperty 'Definition'
+& $env:TEST_PHP_EXECUTABLE 'run-tests.php' --show-diff tests
+if (-not $?) {
+    throw "tests failed with errorlevel $LastExitCode"
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,94 @@
+version: "{branch}.build.{build}"
+skip_tags: true
+
+branches:
+  only:
+    - develop
+
+clone_folder:  c:\projects\pecl-pcs
+
+install:
+  ps: .appveyor\install.ps1
+
+cache:
+  c:\build-cache -> appveyor.yml, .appveyor\install.ps1
+
+environment:
+  BIN_SDK_VER: 2.2.0
+  matrix:
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      ARCH: x64
+      VC: vc14
+      PHP_VER: 7.0
+      TS: 0
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
+      ARCH: x64
+      VC: vc14
+      PHP_VER: 7.1
+      TS: 0
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x64
+      VC: vc15
+      PHP_VER: 7.2
+      TS: 0
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x64
+      VC: vc15
+      PHP_VER: 7.2
+      TS: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x86
+      VC: vc15
+      PHP_VER: 7.2
+      TS: 0
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x86
+      VC: vc15
+      PHP_VER: 7.2
+      TS: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x64
+      VC: vc15
+      PHP_VER: 7.3
+      TS: 0
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x64
+      VC: vc15
+      PHP_VER: 7.3
+      TS: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x86
+      VC: vc15
+      PHP_VER: 7.3
+      TS: 0
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x86
+      VC: vc15
+      PHP_VER: 7.3
+      TS: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x64
+      VC: vc15
+      PHP_VER: 7.4
+      TS: 0
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x64
+      VC: vc15
+      PHP_VER: 7.4
+      TS: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x86
+      VC: vc15
+      PHP_VER: 7.4
+      TS: 0
+    - APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2017
+      ARCH: x86
+      VC: vc15
+      PHP_VER: 7.4
+      TS: 1
+
+build_script:
+  ps: .appveyor\build.ps1
+
+test_script:
+  ps: .appveyor\test.ps1


### PR DESCRIPTION
We add basic AppVeyor CI integration for building the extension and
running the tests.  We add jobs for all twelve variations currently
built on PECL, plus a single job for each PHP 7.0 and 7.1 for the most
typical variation on Windows (x64, NTS).  We do not add jobs for PHP 5,
mostly because AppVeyor does not support Visual Studio 2011 which would
be required for PHP 5.5 and 5.6, and also because we would need to
fiddle with the PHP-SDK v1.  Furthermore, 14 jobs already seem to be
a lot.